### PR TITLE
do not auto-decode byte strings

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,8 @@ latest changes in development for next release
 
 .. THANKS FOR CONTRIBUTING; MENTION WHAT YOU DID IN THIS SECTION HERE!
 
+* make sure unicode is passed to ``scrubadub``
+
 
 0.1.0
 -----

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,23 +32,23 @@ incorporating it into your python scripts like this:
     >>> import scrubadub
 
     # John may be a cat, but he doesn't want other people to know it.
-    >>> text = "John is a cat"
+    >>> text = u"John is a cat"
 
     # Replace names with {{NAME}} placeholder. This is the scrubadub default
     # because it maximally omits any information about people.
     >>> placeholder_text = scrubadub.clean_with_placeholders(text)
     >>> placeholder_text
-    "{{NAME}} is a cat"
+    u"{{NAME}} is a cat"
 
 ..    # Replace names with {{NAME-ID}} anonymous, but consistent IDs.
     >>> identifier_text = scrubadub.clean_with_identifiers(text)
     >>> identifier_text
-    "{{NAME-1287}} is a cat"
+    u"{{NAME-1287}} is a cat"
 
 ..    # Replace names with random, gender-consistent names
     >>> surrogate_text = scrubadub.clean_with_surrogates(text)
     >>> surrogate_text
-    "Billy is a cat"
+    u"Billy is a cat"
 
 ..    # For more fine-grained control, you can subclass Scrubber and adapt your
     # approach for your particular use case. For example, if you have a specific
@@ -58,10 +58,10 @@ incorporating it into your python scripts like this:
     ...     def clean_email_addresses(self, text):
     ...         return text
     ...
-    >>> text = "John's email address is cat@gmail.com"
+    >>> text = u"John's email address is cat@gmail.com"
     >>> text = scrubadub.clean_with_placeholders(text, cls=NoEmailScrubber)
     >>> text
-    "{{NAME}}'s email address is cat@gmail.com'"
+    u"{{NAME}}'s email address is cat@gmail.com'"
 
 
 

--- a/requirements/python
+++ b/requirements/python
@@ -1,3 +1,2 @@
 textblob
-chardet
 argcomplete

--- a/scrubadub/exceptions.py
+++ b/scrubadub/exceptions.py
@@ -1,13 +1,18 @@
 
+
 # this is the base exception that is thrown by scrubadub to make it
 # easy to suppress all Scrubadub exceptions
 class ScrubadubException(Exception):
+
     def render(self, msg):
         return msg % vars(self)
 
 
 class UnicodeRequired(ScrubadubException):
-    """Scrubadub requires"""
+    """Scrubadub requires unicode. Throw a useful error to lead users to
+    the promised land.
+    """
+
     def __str__(self):
         return self.render((
             'scrubadub works best with unicode.\n'
@@ -16,4 +21,3 @@ class UnicodeRequired(ScrubadubException):
             'But unicode sandwiches are awesome.\n'
             'http://bit.ly/unipain @nedbat\n'
         ))
-

--- a/scrubadub/exceptions.py
+++ b/scrubadub/exceptions.py
@@ -1,0 +1,19 @@
+
+# this is the base exception that is thrown by scrubadub to make it
+# easy to suppress all Scrubadub exceptions
+class ScrubadubException(Exception):
+    def render(self, msg):
+        return msg % vars(self)
+
+
+class UnicodeRequired(ScrubadubException):
+    """Scrubadub requires"""
+    def __str__(self):
+        return self.render((
+            'scrubadub works best with unicode.\n'
+            'Frustrated by unicode?\n'
+            'Yeah, me too.\n'
+            'But unicode sandwiches are awesome.\n'
+            'http://bit.ly/unipain @nedbat\n'
+        ))
+

--- a/scrubadub/scrubbers.py
+++ b/scrubadub/scrubbers.py
@@ -1,7 +1,8 @@
 import re
 
 from textblob import TextBlob
-import chardet
+
+import exceptions
 
 
 class Scrubber(object):
@@ -13,6 +14,9 @@ class Scrubber(object):
         """This is the master method that cleans all of the filth out of the
         dirty dirty ``text``.
         """
+        if not isinstance(text, unicode):
+            raise exceptions.UnicodeRequired
+
         text = self.clean_proper_nouns(text)
         text = self.clean_email_addresses(text)
         return text

--- a/scrubadub/scrubbers.py
+++ b/scrubadub/scrubbers.py
@@ -9,45 +9,13 @@ class Scrubber(object):
     dirty dirty text.
     """
 
-    def decode(self, text):
-        """Decode ``text`` using the `chardet
-        <https://github.com/chardet/chardet>`_ package.
-        """
-        # only decode byte strings into unicode if it hasn't already
-        # been done by a subclass
-        if isinstance(text, unicode):
-            return text
-
-        # empty text? nothing to decode
-        if not text:
-            return u''
-
-        # use chardet to automatically detect the encoding text. if chardet
-        # doesn't know the answer, this will throw a rather ungraceful error
-        max_confidence, max_encoding = 0.0, None
-        result = chardet.detect(text)
-        return text.decode(result['encoding'])
-
-    def encode(self, text, encoding):
-        """Encode the ``text`` in ``encoding`` byte-encoding. This ignores
-        code points that can't be encoded in byte-strings.
-        """
-        return text.encode(encoding, 'ignore')
-
     def clean_with_placeholders(self, text):
         """This is the master method that cleans all of the filth out of the
         dirty dirty ``text``.
         """
-
-        # decode the text as a unicode string as necessary
-        text = self.decode(text)
-
-        # do all the dirty work
         text = self.clean_proper_nouns(text)
         text = self.clean_email_addresses(text)
-
-        # encode the unicode as a byte string
-        return self.encode(text, 'utf-8')
+        return text
 
     def clean_proper_nouns(self, text, replacement="{{NAME}}"):
         """Use part of speech tagging to clean proper nouns out of the dirty

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -8,37 +8,37 @@ class PlaceholderTestCase(unittest.TestCase):
     def test_john(self):
         """Make sure proper names are removed from the text"""
         self.assertEqual(
-            scrubadub.clean_with_placeholders('John is a cat'),
-            '{{NAME}} is a cat',
+            scrubadub.clean_with_placeholders(u'John is a cat'),
+            u'{{NAME}} is a cat',
             'John not replaced with {{NAME}}',
         )
 
     def test_gmail_john(self):
         """Make sure email addresses are removed from text"""
         self.assertEqual(
-            scrubadub.clean_with_placeholders('My email is john@gmail.com'),
-            'My email is {{EMAIL}}',
+            scrubadub.clean_with_placeholders(u'My email is john@gmail.com'),
+            u'My email is {{EMAIL}}',
             'john@gmail.com is not replaced with {{EMAIL}}',
         )
 
     def test_fancy_gmail_john(self):
         """Make sure email addresses are removed from text"""
         self.assertEqual(
-            scrubadub.clean_with_placeholders('My email is john at gmail.com'),
-            'My email is {{EMAIL}}',
+            scrubadub.clean_with_placeholders(u'My email is john at gmail.com'),
+            u'My email is {{EMAIL}}',
             'john at gmail.com is not replaced with {{EMAIL}}',
         )
         self.assertEqual(
-            scrubadub.clean_with_placeholders('My email is john AT gmail.com'),
-            'My email is {{EMAIL}}',
+            scrubadub.clean_with_placeholders(u'My email is john AT gmail.com'),
+            u'My email is {{EMAIL}}',
             'john AT gmail.com is not replaced with {{EMAIL}}',
         )
 
     def test_empty(self):
         """Make sure this returns an empty string"""
         self.assertEqual(
-            scrubadub.clean_with_placeholders(''),
-            '',
+            scrubadub.clean_with_placeholders(u''),
+            u'',
             'empty string is not preserved',
         )
 
@@ -46,6 +46,6 @@ class PlaceholderTestCase(unittest.TestCase):
         """Make sure unicode works, too"""
         self.assertEqual(
             scrubadub.clean_with_placeholders(u'John is a cat'),
-            '{{NAME}} is a cat',
+            u'{{NAME}} is a cat',
             'unicode strings work too',
         )

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -42,10 +42,7 @@ class PlaceholderTestCase(unittest.TestCase):
             'empty string is not preserved',
         )
 
-    def test_unicode(self):
+    def test_not_unicode(self):
         """Make sure unicode works, too"""
-        self.assertEqual(
-            scrubadub.clean_with_placeholders(u'John is a cat'),
-            u'{{NAME}} is a cat',
-            'unicode strings work too',
-        )
+        with self.assertRaises(scrubadub.exceptions.UnicodeRequired):
+            scrubadub.clean_with_placeholders('John is a byte string')


### PR DESCRIPTION
* [x] get rid of the `Scrubber.encode` and `Scrubber.decode` methods
* [x] throw nice error if incoming text is not unicode
* [x] add instructions to the docs to make it clear how to handle unicode, but have the package assume that everything is unicode to begin with. that's the same assumption that textblob makes and it is a lot easier to throw a nice, informative error

